### PR TITLE
Require glue 1.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
-    glue-core>=1.6.1
+    glue-core>=1.8.0
     qtpy>=1.9
     glue-small-multiples>=1.0
     glue-heatmap>=1.0


### PR DESCRIPTION
Fixes a critical Qt5 bug with the link editor